### PR TITLE
Add Room Description

### DIFF
--- a/assets/css/meetings.scss
+++ b/assets/css/meetings.scss
@@ -231,60 +231,69 @@ div.inline-feature-warning {
             }
         }
 
-        article#details {
-            position: relative;
-            div {
-                &:first-of-type {
-                    width: calc(100% - 185px);
-                }
-                img {
-                    position: relative;
-                    top: 12px;
-
-                    &.info-icon {
-                        top: 7px;
-                        margin-right: 7px;
-                    }
-                }
-
-                span {
-                    &.red {
-                        color: #D60000;
-                    }
-
-                    &.creator-date {
-                        color: #636971;
-                        font-size: 12px;
-                        float: right;
-                        font-style: italic;
-                        margin: 10px 0;
-                    }
-
-                    &.has-changed {
-                        animation: alert 1s;
-                    }
-
-                    @keyframes alert {
-                        0% {
-                            color: #D60000;
-                        }
-                        50% {
-                            color: darken(#D60000, 7%);
-                        }
-                        100% {
-                            color: inherit;
-                        }
-                    }
+        section.contents {
+            article.description {
+                overflow: hidden;
+                p {
+                    text-align: left;
                 }
             }
+            article.details {
+                position: relative;
+                div {
+                    &:first-of-type {
+                        width: calc(100% - 185px);
+                    }
+                    img {
+                        position: relative;
+                        top: 12px;
 
-            span.participants {
-                position: absolute;
-                right: 0;
-                top: 10px;
-                font-size: 14px;
-                font-weight: 200;
-                color: #636971;
+                        &.info-icon {
+                            top: 7px;
+                            margin-right: 7px;
+                        }
+                    }
+
+                    span {
+                        &.red {
+                            color: #D60000;
+                        }
+
+                        &.creator-date {
+                            color: #636971;
+                            font-size: 12px;
+                            float: right;
+                            font-style: italic;
+                            margin: 10px 0;
+                        }
+
+                        &.has-changed {
+                            animation: alert 1s;
+                        }
+
+                        @keyframes alert {
+                            0% {
+                                color: #D60000;
+                            }
+                            50% {
+                                color: darken(#D60000, 7%);
+                            }
+                            100% {
+                                color: inherit;
+                            }
+                        }
+                    }
+                }
+
+
+                span.participants {
+                    position: absolute;
+                    right: 0;
+                    top: 10px;
+                    font-size: 14px;
+                    font-weight: 200;
+                    color: #636971;
+                }
             }
         }
         > footer {

--- a/lib/Routes/Rooms/RoomAdd.php
+++ b/lib/Routes/Rooms/RoomAdd.php
@@ -156,6 +156,7 @@ class RoomAdd extends MeetingsController
                 $meeting->courses[] = new \Course($json['cid']);
                 $meeting->user_id = $user->id;
                 $meeting->name = trim($json['name']);
+                $meeting->description = trim($json['description']);
                 $meeting->driver = $json['driver'];
                 $meeting->server_index = $json['server_index'];
                 $meeting->attendee_password = Helper::createPassword();

--- a/lib/Routes/Rooms/RoomEdit.php
+++ b/lib/Routes/Rooms/RoomEdit.php
@@ -46,6 +46,7 @@ class RoomEdit extends MeetingsController
 
         $meetingCourse = new MeetingCourse([$room_id, $json['cid']]);
         $name = trim($json['name']);
+        $description = trim($json['description']);
         $allow_change_driver = (isset($json['driver']) && !empty($json['driver'])) || !isset($json['driver']);
         $allow_change_server_index = (isset($json['server_index']) && is_numeric($json['server_index'])) || !isset($json['server_index']);
         // Checking Course Type
@@ -81,6 +82,7 @@ class RoomEdit extends MeetingsController
 
             $meeting = $meetingCourse->meeting;
             $meeting->name = $name;
+            $meeting->description = $description;
             !isset($json['recordingUrl']) ?: $meeting->recording_url = utf8_decode($json['recording_url']);
             !isset($json['join_as_moderator']) ?: $meeting->join_as_moderator = $json['join_as_moderator'];
             !isset($json['driver']) ?: $meeting->driver = $json['driver'];
@@ -107,7 +109,7 @@ class RoomEdit extends MeetingsController
                 } catch (Exception $e) {
                     throw new Error($e->getMessage(), 404);
                 }
-                
+
                 if (!is_numeric($json['features']['duration'])) {
                     $json['features']['duration'] = "240";
                 }

--- a/migrations/051_add_description_column_to_meeting.php
+++ b/migrations/051_add_description_column_to_meeting.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Adds a column to store description in vc_meeting table.
+ *
+ * @author Farbod Zamani Broujeni (zamani@elan-ev.de)
+ */
+class AddDescriptionColumnToMeeting extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    function description()
+    {
+        return 'Adds description column to store a some extra info in vc_meeting table.';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function up()
+    {
+        $db = DBManager::get();
+        $db->exec(
+            'ALTER TABLE
+                vc_meetings
+            ADD COLUMN
+                description text NULL DEFAULT NULL AFTER name'
+        );
+
+        SimpleORMap::expireTableScheme();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    function down()
+    {
+        $db = DBManager::get();
+        $db->exec(sprintf('ALTER TABLE vc_meetings DROP COLUMN description'));
+
+        SimpleORMap::expireTableScheme();
+    }
+}

--- a/vueapp/components/meeting/MeetingComponent.vue
+++ b/vueapp/components/meeting/MeetingComponent.vue
@@ -31,8 +31,11 @@
                 @deleteRoom="deleteRoom"
             />
         </header>
-        <section>
-            <article id="details">
+        <section class="contents">
+            <article v-if="room.description" class="description">
+                <p v-html="nl2Br(room.description)"></p>
+            </article>
+            <article class="details">
                 <span v-if="showParticipantCount" class="participants" v-text="showParticipantCount"></span>
                 <div v-if="course_config.display.editRoom && room.is_default == 1">
                     <StudipIcon class="info-icon" icon="star"
@@ -413,6 +416,10 @@ export default {
 
         showQRCode() {
             this.$emit('displayQRCode', this.getNonReactiveRoom());
+        },
+
+        nl2Br(pureText) {
+            return pureText.replace(/(?:\r\n|\r|\n)/g, '<br>');
         }
     }
 }

--- a/vueapp/components/meeting/add/MeetingAdd.vue
+++ b/vueapp/components/meeting/add/MeetingAdd.vue
@@ -32,6 +32,15 @@
                             <input type="text" v-model.trim="room['name']" id="name">
                         </label>
                         <label>
+                            <span v-translate>
+                                Beschreibung
+                            </span>
+                            <textarea
+                                v-model="room['description']"
+                                maxlength="150"
+                            ></textarea>
+                        </label>
+                        <label>
                             <input type="checkbox"
                             id="default"
                             :true-value="1"
@@ -610,7 +619,8 @@ export default {
                                             //sanitize - html tags
                                             var value = this.room['features'][config_feature.name];
                                             var text = '';
-                                            if (config_feature.name == 'welcome') {
+                                            // We need both welcome and description to contain light html codes.
+                                            if (config_feature.name == 'welcome' && config_feature.name == 'description') {
                                                 text = value.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
                                             } else {
                                                 text = value.replace(/(<([^>]+)>)/gi, "");


### PR DESCRIPTION
This PR fixes #407 
### How it works:
- A new migration to add description column is added.
- in add and edit room and new textarea is introduced under room name.
- It sets to contain 150 words
- It does not provide any ckeditor or wysiwyg capabilities, as it is a limitation os StudIP to use those features in plugins, specially in vue.
- The validation is applied to only take out script html tag, other html tags are allowed.
- It presents the description, in the contents section of the Meeting Component.