### PR TITLE
Upgrading guzzle to 7.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
         }
     },
     "require": {
-        "guzzlehttp/guzzle": "7.4.5",
-        "guzzlehttp/psr7": "^2.4",
+        "guzzlehttp/guzzle": "7.5.1",
+        "guzzlehttp/psr7": "^2.6.2",
         "slim/slim": "^3.12",
         "setasign/fpdi": "^2.0"
     }


### PR DESCRIPTION
This PR is meant to bring a sync versioning of guzzle between SOP and this plugin. However, due to the fact that Meeting plugin is not invoking any SOP classes any more and also the `autoload` is required only upon perform. Theoretically, there won't be any collision.