### PR TITLE
Make subject of feedback mail configurable, raise version

### DIFF
--- a/lib/Routes/Feedback/FeedbackSubmit.php
+++ b/lib/Routes/Feedback/FeedbackSubmit.php
@@ -53,7 +53,10 @@ class FeedbackSubmit extends MeetingsController
                     'type' => 'error'
                 ];
             } else if ($json && $meetingCourse && $current_user) {
-                $subject = I18N::_("Feedback zum Meetings-Plugin");
+                $subject = Driver::getGeneralConfigValue('feedback_mail_subject');
+                if (!$subject) {
+                    $subject = I18N::_("Feedback zum Meetings-Plugin");
+                }
                 $mailbody = $this->generateMessageBody($json, $meetingCourse, $current_user);
                 $feedback = new StudipMail();
 

--- a/lib/Routes/Feedback/FeedbackSubmitPublic.php
+++ b/lib/Routes/Feedback/FeedbackSubmitPublic.php
@@ -49,7 +49,10 @@ class FeedbackSubmitPublic extends MeetingsController
                     'type' => 'error'
                 ];
             } else if ($json && $meetingCourse) {
-                $subject = I18N::_("Feedback zum Meetings-Plugin");
+                $subject = Driver::getGeneralConfigValue('feedback_mail_subject');
+                if (!$subject) {
+                    $subject = I18N::_("Feedback zum Meetings-Plugin");
+                }
                 $mailbody = $this->generateMessageBody($json, $meetingCourse);
                 $feedback = new StudipMail();
 

--- a/plugin.manifest
+++ b/plugin.manifest
@@ -1,7 +1,7 @@
 pluginname=Meetings
 pluginclassname=MeetingPlugin
 origin=elan-ev
-version=2.82
+version=2.82.2
 studipMinVersion=5.0
 studipMaxVersion=6.0.99
 

--- a/vueapp/components/meeting/admin/MeetingAdminConfig.vue
+++ b/vueapp/components/meeting/admin/MeetingAdminConfig.vue
@@ -18,6 +18,10 @@
                     <input type="text" v-model.trim="general_config['feedback_contact_address']">
                 </label>
                 <label>
+                     {{ $gettext('Feedback Betreff') }}
+                 <input type="text" v-model.trim="general_config['feedback_mail_subject']">
+                </label>
+                <label>
                     {{ $gettext('Feedback Absenderadresse') }}
                     <br>
                     <input type="radio" name="feedback-contact-address"


### PR DESCRIPTION
Unser IT-Support weiß nicht, was das MeetingPlugin ist. 
Meistens liegt auch kein Fehler im Plugin vor, sondern ein Problem mit BigBlueButton etc. 
So hat der Admin nun die Möglichkeit den Betreff der Feedback Mail zu konfigurieren. 