### PR TITLE
Rework and update logoutUrl and return mechanism

### DIFF
--- a/app/views/index/return.php
+++ b/app/views/index/return.php
@@ -1,12 +1,17 @@
-<h4>
+<h4 id="loading">
     <img style="vertical-align: middle; margin-right: 3px;" src="<?= Assets::url('images/ajax-indicator-black.svg') ?>" width="24" height="24" alt="waiting">
     <span><?= $_('Vorgang läuft. Bitte warten Sie einen Moment') ?>&hellip;</span>
 </h4>
+<div id="duplicationInfo" class="hidden" style="display: none;">
+    <?= MessageBox::info(_('Dies ist ein doppelter Tab. Bitte schließen Sie dieses Fenster manuell oder nutzen Sie den Button "Zurück zu den Meetings". Ihr Browser blockiert möglicherweise das automatische Schließen.')) ?>
+    <?= \Studip\LinkButton::create(_('Zurück zu den Meetings'), $return_url)?>
+</div>
 <script type="text/javascript">
     window.onload = () => {
         if (typeof window.page_available !== 'undefined') {
             if (window.page_available) {
-                window.close();
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('duplicationInfo').style.display = 'block';
             } else {
                 setTimeout(() => {
                     window.open('<?= $return_url ?>', "_self");


### PR DESCRIPTION
This PR fixes #491,

- Due to securty measures the `window.close()` does not work anymore, unless the window has been opened by the (self) script, therefore we changed the closing mechanism to a information with reuse button in case of a return ends up in a duplicated tab!

- As for the `generateMeetingBaseURL` rework, it is worth knowing, that the PluginEngine::getLink was returning only the path relative to the studip url at the time of implementing like 4 years ago (I think it was v5.0 or latst v4 of Studip). However, now it returns full url with some tweaks which have been considered in the changes of this PR!

**NOTE:** This PR would be landed first on v6.x (aka main) branch then it needs to be cherry picked to v5.x